### PR TITLE
Adjust episode cover for timeline visibility

### DIFF
--- a/components/app.js
+++ b/components/app.js
@@ -76,6 +76,31 @@ window.App = () => {
     if (moment) {
       setSelectedId(moment.id);
       
+      // Check if comic reader is currently open (showing cover)
+      const isComicReaderOpen = typeof window.scrollComicToEpisode === 'function';
+      
+      // If comic reader is open and clicking a comic episode, scroll to that episode
+      if (isComicReaderOpen && isComicEpisode(moment)) {
+        console.log('Comic reader is open, scrolling to episode:', moment.id);
+        const scrolled = window.scrollComicToEpisode(moment.id);
+        if (scrolled) {
+          // Episode scrolled successfully, trigger zoom
+          if (zoomCallback) {
+            zoomCallback(moment);
+          }
+          return; // Don't proceed with normal opening logic
+        }
+      }
+      
+      // If comic reader is open and clicking a non-comic episode, close the comic reader
+      if (isComicReaderOpen && !isComicEpisode(moment)) {
+        console.log('Comic reader is open, closing to show non-comic episode:', moment.id);
+        if (window.setBlogPostContent) {
+          window.setBlogPostContent(null);
+        }
+        // Continue with normal flow to show the episode
+      }
+      
       // For comic episodes, skip the overlay entirely and go straight to comic
       if (isComicEpisode(moment)) {
         console.log('Comic episode detected - bypassing overlay, opening comic directly');

--- a/components/comicReader.js
+++ b/components/comicReader.js
@@ -622,6 +622,18 @@ window.ComicReader = ({ content, onClose }) => {
   }, [episodeData, isMobile]); // Add isMobile dependency
   
 
+  // Update body class when comic is open/closed to hide footer
+  React.useEffect(() => {
+    if (!showCover) {
+      document.body.classList.add('comic-is-open');
+    } else {
+      document.body.classList.remove('comic-is-open');
+    }
+    return () => {
+      document.body.classList.remove('comic-is-open');
+    };
+  }, [showCover]);
+
   // Function to transition from cover to flipbook
   const openComicBook = () => {
     setShowCover(false);
@@ -1117,12 +1129,6 @@ window.ComicReader = ({ content, onClose }) => {
     }
   }
   
-  if (showCover && isVisible && styles.coverOverlayStyle) {
-    overlayChildren.push(React.createElement('div', {
-      key: 'cover-overlay',
-      style: styles.coverOverlayStyle || {}
-    }, isMobile ? '📖 Tap to start reading' : '🖱️ Click to open comic book'));
-  }
   
   // Prevent touch events from reaching elements underneath (like the globe)
   const handleOverlayTouchStart = (e) => {

--- a/components/comicReader.js
+++ b/components/comicReader.js
@@ -253,6 +253,36 @@ window.ComicReader = ({ content, onClose }) => {
       .sort((a, b) => a.date - b.date);
   }, []);
 
+  // Function to scroll to a specific episode by ID (exposed globally for timeline clicks)
+  const scrollToEpisode = React.useCallback((episodeId) => {
+    if (!showCover || !splideRef.current) {
+      return false; // Can't scroll if not showing cover or Splide not initialized
+    }
+    
+    const allEpisodes = getAllComicEpisodes();
+    const targetIndex = allEpisodes.findIndex(ep => ep.id === episodeId);
+    
+    if (targetIndex !== -1 && splideRef.current.index !== targetIndex) {
+      isSplideUpdatingRef.current = true;
+      splideRef.current.go(targetIndex);
+      // Reset flag after transition
+      setTimeout(() => {
+        isSplideUpdatingRef.current = false;
+      }, 500);
+      return true;
+    }
+    
+    return false;
+  }, [showCover, getAllComicEpisodes]);
+
+  // Expose scrollToEpisode globally so timeline can trigger it
+  React.useEffect(() => {
+    window.scrollComicToEpisode = scrollToEpisode;
+    return () => {
+      delete window.scrollComicToEpisode;
+    };
+  }, [scrollToEpisode]);
+
   // Track if Splide is being updated internally (to prevent re-init loop)
   const isSplideUpdatingRef = React.useRef(false);
 

--- a/components/comicReader/styles.js
+++ b/components/comicReader/styles.js
@@ -81,8 +81,8 @@ const STYLE_CONFIG = {
     desktop: {
       // Desktop is always landscape
       cover: {
-        width: '400px',
-        height: '600px'
+        width: '380px',
+        height: '560px'
       },
       open: {
         width: '800px',
@@ -332,7 +332,7 @@ const getDeviceStyles = (deviceType, state = {}) => {
     left: 0,
     width: '100vw',
     height: showCover ? `calc(100% - ${footerHeight}px)` : '100%',
-    background: 'rgba(0, 0, 0, 0.2)',
+    background: showCover ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.8)', // Darker when comic is open to focus on comic
     display: 'flex',
     flexDirection: isMobile ? 'column' : 'row',
     alignItems: 'center',

--- a/components/comicReader/styles.js
+++ b/components/comicReader/styles.js
@@ -324,17 +324,21 @@ const getDeviceStyles = (deviceType, state = {}) => {
   const isPortrait = orientation === 'portrait';
   
   // Shared overlay style (same for all devices)
+  // When showing cover, reduce height to leave space for footer timeline (~150px)
+  const footerHeight = 150; // Approximate footer height to leave space for timeline
   const comicOverlayStyle = {
     position: 'fixed',
     top: 0,
     left: 0,
     width: '100vw',
-    height: '100%',
+    height: showCover ? `calc(100% - ${footerHeight}px)` : '100%',
     background: 'rgba(0, 0, 0, 0.2)',
     display: 'flex',
     flexDirection: isMobile ? 'column' : 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    paddingTop: showCover ? (isMobile ? '20px' : '40px') : '0',
+    paddingBottom: showCover ? '20px' : '0', // Small padding to ensure cover doesn't touch footer area
     zIndex: 10000,
     backdropFilter: 'blur(2px)',
     touchAction: 'none',

--- a/components/footer.css
+++ b/components/footer.css
@@ -18,14 +18,15 @@ footer {
     right: 0;
     background: var(--background-dark); /* Dark background */
     border-top: 1px solid var(--border-dark);
-    z-index: 20;
+    z-index: 10001; /* Higher than comic overlay (10000) to ensure timeline is always accessible */
 }
 
 .timeline-container {
     position: relative;
     overflow-x: auto;
+    overflow-y: visible;
     white-space: nowrap;
-    padding: 32px 0; /* For year clearance */
+    padding: 80px 0 32px 0; /* Increased top padding for thumbnail clearance */
     background: var(--transparent);
     border-radius: 0;
     width: 100%;
@@ -169,6 +170,31 @@ footer {
     transform: scale(1.1);
 }
 
+.comic-thumbnail-indicator {
+    position: absolute;
+    top: -72px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 12;
+    width: 56px;
+    height: auto;
+    aspect-ratio: 3 / 4;
+    border-radius: 8px;
+    border: 1px solid var(--border-dark);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    object-fit: cover;
+    opacity: 0.9;
+    transition: all 0.3s ease;
+    background: var(--background-dark);
+}
+
+.timeline-entry:hover .comic-thumbnail-indicator,
+.timeline-entry.selected .comic-thumbnail-indicator {
+    opacity: 1;
+    transform: translateX(-50%) scale(1.1);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
@@ -221,7 +247,8 @@ footer {
 
 @media (max-width: 640px) {
     .timeline-container {
-        padding: 42px 0;
+        padding: 80px 0 42px 0; /* Increased top padding for thumbnail clearance on mobile */
+        overflow-y: visible;
         touch-action: pan-x pan-y pinch-zoom; /* Enable all touch actions */
         -webkit-overflow-scrolling: touch; /* Ensure momentum scrolling */
         scroll-behavior: smooth; /* Smooth scrolling */

--- a/components/footer.css
+++ b/components/footer.css
@@ -16,9 +16,20 @@ footer {
     bottom: 0;
     left: 0;
     right: 0;
-    background: var(--background-dark); /* Dark background */
-    border-top: 1px solid var(--border-dark);
+    background: transparent; /* Transparent background for floating effect */
+    border-top: none; /* Remove border */
     z-index: 10001; /* Higher than comic overlay (10000) to ensure timeline is always accessible */
+    overflow: visible; /* Allow thumbnails to float above */
+    clip-path: none; /* Prevent clipping */
+    contain: none; /* Prevent containment */
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+/* Hide footer when comic is open */
+body.comic-is-open footer {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 .timeline-container {
@@ -26,7 +37,7 @@ footer {
     overflow-x: auto;
     overflow-y: visible;
     white-space: nowrap;
-    padding: 80px 0 32px 0; /* Increased top padding for thumbnail clearance */
+    padding: 60px 0 16px 0; /* Increased top padding to accommodate thumbnails, reduced bottom padding */
     background: var(--transparent);
     border-radius: 0;
     width: 100%;
@@ -36,7 +47,8 @@ footer {
     -ms-overflow-style: none; /* Hide scrollbar for IE/Edge */
     overscroll-behavior-x: contain; /* Prevent overscroll bounce */
     touch-action: pan-x pan-y pinch-zoom; /* Enable all touch actions */
-    will-change: transform; /* Optimize for animations */
+    clip-path: none; /* Prevent clipping */
+    contain: none; /* Prevent containment that could clip */
 }
 
 .timeline-container::-webkit-scrollbar {
@@ -49,11 +61,14 @@ footer {
     padding: 0 16px;
     position: relative;
     width: max-content; /* Ensure timeline width matches content */
+    overflow: visible; /* Allow thumbnails to float above */
+    clip-path: none; /* Prevent clipping */
+    contain: none; /* Prevent containment */
 }
 
 .timeline-line {
     position: absolute;
-    top: 25px; /* Line position */
+    top: 58px; /* Centered in the dots */
     left: 16px;
     height: 2px;
     background: var(--primary-orange);
@@ -97,6 +112,9 @@ footer {
     min-width: 180px; /* Minimum width to prevent shrinking too much */
     position: relative;
     scroll-snap-align: center; /* Snap each entry to center */
+    overflow: visible; /* Allow thumbnails to float above */
+    clip-path: none; /* Prevent clipping */
+    contain: none; /* Prevent containment */
 }
 
 .timeline-entry:hover .timeline-card {
@@ -105,14 +123,13 @@ footer {
 }
 
 .timeline-entry.selected .timeline-card {
-    background: var(--white-10);
     transform: translateY(-2px);
     box-shadow: 0 4px 10px var(--white-30);
 }
 
 .timeline-dot {
     position: absolute;
-    top: -11px; /* Center vertically on 2px line */
+    top: -6px; /* Center vertically on 2px line: line center is at 1px, dot center is at 5px, so -6px positions dot center on line center */
     left: 50%;
     transform: translateX(-50%);
     width: 10px;
@@ -132,16 +149,17 @@ footer {
 }
 
 .timeline-card {
-    background: var(--white-05);
+    background: rgba(26, 26, 26, 0.8); /* Darker background for better visibility */
     border-radius: 8px;
     padding: 8px 12px;
     transition: all 0.3s ease;
     opacity: 0;
     animation: fadeIn 0.5s forwards;
     animation-delay: calc(var(--index) * 0.2s);
-    margin-top: 12px;
+    margin-top: 24px; /* Increased from 12px to move card lower */
     white-space: normal;
     position: relative;
+    overflow: visible; /* Allow thumbnails to float above */
 }
 
 .full-moment-indicator {
@@ -172,26 +190,29 @@ footer {
 
 .comic-thumbnail-indicator {
     position: absolute;
-    top: -72px;
+    top: -15px;
     left: 50%;
-    transform: translateX(-50%);
-    z-index: 12;
-    width: 56px;
-    height: auto;
+    transform: translateX(-50%) translateY(-50%);
+    z-index: 20; /* Higher than timeline-line (10) and timeline-dot (11) */
+    width: 60px;
+    height: 80px;
     aspect-ratio: 3 / 4;
-    border-radius: 8px;
+    border-radius: 6px;
     border: 1px solid var(--border-dark);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     object-fit: cover;
     opacity: 0.9;
     transition: all 0.3s ease;
     background: var(--background-dark);
+    pointer-events: auto;
+    clip-path: none; /* Ensure no clipping */
+    contain: none; /* Prevent containment */
 }
 
 .timeline-entry:hover .comic-thumbnail-indicator,
 .timeline-entry.selected .comic-thumbnail-indicator {
     opacity: 1;
-    transform: translateX(-50%) scale(1.1);
+    transform: translateX(-50%) translateY(-50%) scale(1.1);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -247,7 +268,7 @@ footer {
 
 @media (max-width: 640px) {
     .timeline-container {
-        padding: 80px 0 42px 0; /* Increased top padding for thumbnail clearance on mobile */
+        padding: 60px 0 16px 0; /* Increased top padding to match desktop, reduced bottom padding */
         overflow-y: visible;
         touch-action: pan-x pan-y pinch-zoom; /* Enable all touch actions */
         -webkit-overflow-scrolling: touch; /* Ensure momentum scrolling */
@@ -291,14 +312,14 @@ footer {
     }
     .timeline-card {
         padding: 6px 10px;
-        margin-top: 0px;
+        margin-top: 20px; /* Move card lower on mobile to accommodate thumbnails */
     }
     .timeline-line {
-        top: 18px;
+        top: 58px;
         left: 16px;
     }
     .timeline-dot {
-        top: -28px; /* Center on line for 8px dot */
+        top: -5px; /* Center vertically on 2px line: line center is at 1px, dot center is at 4px (for 8px dot), so -5px positions dot center on line center */
         width: 8px;
         height: 8px;
     }
@@ -316,5 +337,9 @@ footer {
         height: 20px;
         top: -4px;
         right: -4px;
+    }
+    .comic-thumbnail-indicator {
+        top: -15px; /* Position above the timeline entry on mobile */
+        transform: translateX(-50%) translateY(-50%); /* Center on the dot position */
     }
 }

--- a/components/footer.js
+++ b/components/footer.js
@@ -406,7 +406,16 @@ window.Footer = ({ handleTimelineClick, selectedId, setSelectedId, selectedTag, 
                   React.createElement(
                     'div',
                     { className: 'timeline-card' },
-                    moment.fullLink !== '#' && React.createElement(
+                    moment.isComic && moment.fullLink !== '#' && React.createElement(
+                      'img',
+                      { 
+                        className: 'comic-thumbnail-indicator', 
+                        src: `${moment.fullLink.replace(/\/$/, '')}/cover.png`,
+                        alt: `${moment.title} cover`,
+                        title: 'Comic book available'
+                      }
+                    ),
+                    !moment.isComic && moment.fullLink !== '#' && React.createElement(
                       'span',
                       { className: 'full-moment-indicator', title: 'Full blog post available' },
                       '📖'

--- a/components/footer.js
+++ b/components/footer.js
@@ -291,6 +291,7 @@ window.Footer = ({ handleTimelineClick, selectedId, setSelectedId, selectedTag, 
       });
     }
 
+
     // Scroll to selected moment, centering it in the timeline
     if (selectedId) {
       const selectedEntry = document.querySelector(`.timeline-entry[data-id="${selectedId}"]`);
@@ -403,18 +404,18 @@ window.Footer = ({ handleTimelineClick, selectedId, setSelectedId, selectedTag, 
                     className: 'timeline-dot',
                     style: { width: `${10}px`, height: `${10}px` }
                   }),
+                  moment.isComic && moment.fullLink !== '#' && React.createElement(
+                    'img',
+                    { 
+                      className: 'comic-thumbnail-indicator', 
+                      src: `${moment.fullLink.replace(/\/$/, '')}/cover.png`,
+                      alt: `${moment.title} cover`,
+                      title: 'Comic book available'
+                    }
+                  ),
                   React.createElement(
                     'div',
                     { className: 'timeline-card' },
-                    moment.isComic && moment.fullLink !== '#' && React.createElement(
-                      'img',
-                      { 
-                        className: 'comic-thumbnail-indicator', 
-                        src: `${moment.fullLink.replace(/\/$/, '')}/cover.png`,
-                        alt: `${moment.title} cover`,
-                        title: 'Comic book available'
-                      }
-                    ),
                     !moment.isComic && moment.fullLink !== '#' && React.createElement(
                       'span',
                       { className: 'full-moment-indicator', title: 'Full blog post available' },

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2025.11.19.0943';
+const CACHE_VERSION = '2025.11.19.1042';
 const CACHE_NAME = `whereispaul-v${CACHE_VERSION}`;
 const DYNAMIC_CACHE_NAME = `whereispaul-dynamic-v${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2025.11.17.0757';
+const CACHE_VERSION = '2025.11.19.0943';
 const CACHE_NAME = `whereispaul-v${CACHE_VERSION}`;
 const DYNAMIC_CACHE_NAME = `whereispaul-dynamic-v${CACHE_VERSION}`;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Connects timeline clicks to the comic reader’s cover carousel, adds comic cover thumbnails to the timeline, adjusts overlay/footer behavior, tweaks styles, and bumps the service worker cache.
> 
> - **Comic Reader**:
>   - Exposes `window.scrollComicToEpisode` and uses Splide to scroll covers; updates URL/state on slide change.
>   - Adds `body.comic-is-open` toggling; overlay height/padding adjusted to leave timeline visible on cover; removes cover prompt overlay.
>   - Tweaks desktop cover size (`380x560`); style refinements for overlay/controls.
> - **App Selection Logic (`components/app.js`)**:
>   - When reader is open, timeline clicks on comics scroll to that episode; non-comic clicks close the reader.
>   - Comic moments bypass the overlay and open directly; URL handling preserved.
> - **Footer/Timeline (`components/footer.css`, `components/footer.js`)**:
>   - Footer made transparent, raised z-index; hidden when comic is open.
>   - Adds comic cover thumbnail above comic entries; shows book icon only for non-comic full posts.
>   - Spacing/line/dot positions adjusted; mobile/desktop padding updates.
> - **Service Worker (`sw.js`)**:
>   - Bumps `CACHE_VERSION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f366aa9aed120e88e2f49130e20f8efa5587cb7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->