### PR TITLE
Fix missing mobile navigation arrows

### DIFF
--- a/components/comicReader/render.js
+++ b/components/comicReader/render.js
@@ -280,18 +280,10 @@ const renderCoverNavigation = (deviceType, styles, {
   getNextEpisodeForPages
 }) => {
   const isMobile = deviceType === 'mobile';
-  const isTablet = deviceType === 'tablet';
-  const isDesktop = deviceType === 'desktop';
-  
-  // Only show on desktop and tablet (mobile has its own controls)
-  if (isMobile) {
-    return null;
-  }
-  
   const buttons = [];
   
-  // When pages are open, navigate between pages
-  if (!showCover && previousPage && nextPage) {
+  // When pages are open, navigate between pages (desktop/tablet only)
+  if (!isMobile && !showCover && previousPage && nextPage) {
     // Left button for previous page
     buttons.push(React.createElement('button', {
       key: 'page-prev',
@@ -334,11 +326,11 @@ const renderCoverNavigation = (deviceType, styles, {
     return buttons;
   }
   
-  // When on cover, navigate between episodes
+  // When on cover, navigate between episodes (all devices)
   const hasPreviousEpisode = getPreviousEpisode ? getPreviousEpisode() : null;
   const hasNextEpisode = getNextEpisode ? getNextEpisode() : null;
   
-  if (!hasPreviousEpisode && !hasNextEpisode) {
+  if (!showCover || (!hasPreviousEpisode && !hasNextEpisode)) {
     return null;
   }
   


### PR DESCRIPTION
Enable episode navigation arrows on mobile when viewing the cover to allow users to switch episodes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d63b155d-6b88-46d0-a6a6-970ec22ad43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d63b155d-6b88-46d0-a6a6-970ec22ad43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

