### PR TITLE
Fix timeline hiding logic for non-comic entries

### DIFF
--- a/components/globe.js
+++ b/components/globe.js
@@ -41,14 +41,14 @@ window.GlobeComponent = ({ handleTimelineClick, selectedId, setSelectedId, selec
   const [popoverContent, setPopoverContent] = React.useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   
-  // Check for characters when drawer opens
-  React.useEffect(() => {
-    if (isDrawerOpen && window.characters && window.characters.length > 0) {
-      setCharacters(window.characters);
-    }
-  }, [isDrawerOpen]);
-  const [isBlogDrawerOpen, setIsBlogDrawerOpen] = React.useState(false);
-  const [blogPostContent, setBlogPostContent] = React.useState(null);
+    // Check for characters when drawer opens
+    React.useEffect(() => {
+      if (isDrawerOpen && window.characters && window.characters.length > 0) {
+        setCharacters(window.characters);
+      }
+    }, [isDrawerOpen]);
+    const [isBlogDrawerOpen, setIsBlogDrawerOpen] = React.useState(false);
+    const [blogPostContent, setBlogPostContent] = React.useState(null);
   const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
   const globeInstance = React.useRef(null);
@@ -62,6 +62,30 @@ window.GlobeComponent = ({ handleTimelineClick, selectedId, setSelectedId, selec
   const doubleTapTimeout = React.useRef(null);
   const pinchStartDistance = React.useRef(null);
   const pinchStartAltitude = React.useRef(null);
+
+    // Keep drawer state accessible globally
+    React.useEffect(() => {
+      window.isBlogDrawerOpen = isBlogDrawerOpen;
+      return () => {
+        delete window.isBlogDrawerOpen;
+      };
+    }, [isBlogDrawerOpen]);
+
+    // Provide a global helper to close any open drawer/comic content
+    React.useEffect(() => {
+      window.closeContentDrawer = () => {
+        setIsBlogDrawerOpen(false);
+        setBlogPostContent(null);
+        if (typeof document !== 'undefined' && document.body) {
+          document.body.classList.remove('blog-drawer-open');
+          document.body.classList.remove('comic-is-open');
+        }
+      };
+
+      return () => {
+        delete window.closeContentDrawer;
+      };
+    }, []);
 
   // Expose state setters and refs to window for BlogPostDrawer
   window.setBlogPostContent = setBlogPostContent;


### PR DESCRIPTION
Ensure the timeline is only hidden when a full blog post or comic is open by resetting hidden states on non-comic selections.

Previously, selecting a non-comic entry could leave the `blog-drawer-open` or `comic-is-open` classes on the `document.body`, or the internal drawer state active, causing the timeline to remain hidden even when no content was displayed. This change introduces a global mechanism to explicitly clear these states and body classes when a non-comic entry is selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-20ccec45-5111-4327-ac35-b588ef3fbc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20ccec45-5111-4327-ac35-b588ef3fbc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Non-comic selections now force the timeline to reappear by clearing open drawer/comic state, with new global helpers to close content and expose drawer state.
> 
> - **App (`components/app.js`)**:
>   - Add `ensureTimelineVisible()` to clear `blog-drawer-open`/`comic-is-open` and close drawers via `window.closeContentDrawer`/`setBlogPostContent(null)`.
>   - Update `handleMomentSelection()` to cache `momentIsComic`, call `ensureTimelineVisible()` for non-comic moments, and use it for URL updates and comic-reader logic.
> - **Globe (`components/globe.js`)**:
>   - Expose `window.isBlogDrawerOpen` and keep it in sync with state.
>   - Add global `window.closeContentDrawer()` to close drawers and remove body classes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7870fb6ca60fce11b0fbca26c3d1be9903fc3c42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->